### PR TITLE
Fix Error TypeError: include.some is not a function

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -29,7 +29,7 @@ export class BootstrapConsole {
         }
 
         const appModule = app.get(ConsoleModule);
-        appModule.scan(app, options.module);
+        appModule.scan(app, options.module.imports);
 
         // create a boot function to be use after init
         return {


### PR DESCRIPTION
I was seeing this:

```
Error TypeError: include.some is not a function
    at /Users/bencreasy/code/stock-analysis/backend/node_modules/nestjs-console/src/scanner.ts:15:21
    at Array.filter (<anonymous>)
    at ConsoleScanner.getModules (/Users/bencreasy/code/stock-analysis/backend/node_modules/nestjs-console/src/scanner.ts:14:27)
    at ConsoleScanner.scan (/Users/bencreasy/code/stock-analysis/backend/node_modules/nestjs-console/src/scanner.ts:30:30)
    at ConsoleModule.scan (/Users/bencreasy/code/stock-analysis/backend/node_modules/nestjs-console/src/module.ts:22:43)
    at Function.<anonymous> (/Users/bencreasy/code/stock-analysis/backend/node_modules/nestjs-console/src/bootstrap.ts:37:18)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/bencreasy/code/stock-analysis/backend/node_modules/nestjs-console/lib/bootstrap.js:4:58)
```

I'm dealing with a "dynamic module", if that changes things. If this looks right but you need some more help in integrating it, happy to pull it down and make some changes.